### PR TITLE
Use pythons default split function

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -65,8 +65,8 @@ def get_jaccard(gt, pred):
     gt = gt.replace("/", " ")
     pred = pred.replace("/", " ")
 
-    gt_words = set(gt.split(" "))
-    pred_words = set(pred.split(" "))
+    gt_words = set(gt.split())
+    pred_words = set(pred.split())
 
     intersection = gt_words.intersection(pred_words)
     union = gt_words.union(pred_words)


### PR DESCRIPTION
The default split function is better than splitting just on spaces. Consider the following two examples.
```
"The    quick brown\n fox".split()
['The', 'quick', 'brown', 'fox']
```
vs 
```
"The    quick brown\n fox".split(" ")
['The', '', '', '', 'quick', 'brown\n', 'fox']
```